### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/xborant/09bffcfe-f4c7-45d4-b3c8-bd708c119aa3/ef6e91b5-5995-4085-a261-99b55e2ccf60/_apis/work/boardbadge/eb4283f8-c7c2-4230-8326-55c90d2b0b9b)](https://dev.azure.com/xborant/09bffcfe-f4c7-45d4-b3c8-bd708c119aa3/_boards/board/t/ef6e91b5-5995-4085-a261-99b55e2ccf60/Microsoft.RequirementCategory)
 # notes
 笔记
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/xborant/09bffcfe-f4c7-45d4-b3c8-bd708c119aa3/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.